### PR TITLE
Fix code scanning alert no. 3344: Regular expression injection

### DIFF
--- a/packages/tx/package.json
+++ b/packages/tx/package.json
@@ -60,7 +60,8 @@
     "@ethereumjs/common": "^4.2.0",
     "@ethereumjs/rlp": "^5.0.2",
     "@ethereumjs/util": "^9.0.2",
-    "ethereum-cryptography": "^2.1.3"
+    "ethereum-cryptography": "^2.1.3",
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "@types/minimist": "^1.2.0",

--- a/packages/tx/test/transactionRunner.spec.ts
+++ b/packages/tx/test/transactionRunner.spec.ts
@@ -2,6 +2,7 @@ import { Common } from '@ethereumjs/common'
 import { bytesToHex, toBytes } from '@ethereumjs/util'
 import minimist from 'minimist'
 import { assert, describe, it } from 'vitest'
+import { escapeRegExp } from 'lodash'
 
 import { TransactionFactory } from '../src/index.js'
 
@@ -45,7 +46,7 @@ const EIPs: Record<string, number[] | undefined> = {
 }
 
 describe('TransactionTests', async () => {
-  const fileFilterRegex = file !== undefined ? new RegExp(file + '[^\\w]') : undefined
+  const fileFilterRegex = file !== undefined ? new RegExp(escapeRegExp(file) + '[^\\w]') : undefined
   await getTests(
     (
       _filename: string,


### PR DESCRIPTION
Fixes [https://github.com/Dargon789/ethereumjs-monorepo/security/code-scanning/3344](https://github.com/Dargon789/ethereumjs-monorepo/security/code-scanning/3344)

To fix the problem, we need to sanitize the `file` variable before using it to construct the regular expression. The best way to do this is by using the `_.escapeRegExp` function from the lodash library, which escapes special characters in the input string, making it safe to use in a regular expression.

1. Install the lodash package if it is not already installed.
2. Import the `escapeRegExp` function from lodash.
3. Use `escapeRegExp` to sanitize the `file` variable before constructing the regular expression.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Fix a regular expression injection vulnerability by sanitizing the 'file' variable using lodash's escapeRegExp function and update package.json to include lodash as a dependency.

Bug Fixes:
- Sanitize the 'file' variable using lodash's escapeRegExp function to prevent regular expression injection vulnerabilities.

Build:
- Add lodash as a dependency in the package.json file.