### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -1,0 +1,10 @@
+---
+name: Custom issue template
+about: Describe this issue template's purpose here.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/general.md
+++ b/.github/ISSUE_TEMPLATE/general.md
@@ -4,4 +4,7 @@ about: Open blank issue
 title: ''
 labels: ''
 assignees: ''
+
 ---
+
+

--- a/.github/ISSUE_TEMPLATE/package--ethereumjs-binarytree.md
+++ b/.github/ISSUE_TEMPLATE/package--ethereumjs-binarytree.md
@@ -2,6 +2,9 @@
 name: 'Package: @ethereumjs/binarytree'
 about: Create issue for @ethereumjs/binarytree package
 title: ''
-labels: 'package: binarytree'
+labels: ''
 assignees: ''
+
 ---
+
+

--- a/.github/ISSUE_TEMPLATE/package--ethereumjs-block.md
+++ b/.github/ISSUE_TEMPLATE/package--ethereumjs-block.md
@@ -2,6 +2,9 @@
 name: 'Package: @ethereumjs/block'
 about: Create issue for @ethereumjs/block
 title: ''
-labels: 'package: block'
+labels: ''
 assignees: ''
+
 ---
+
+

--- a/.github/ISSUE_TEMPLATE/package--ethereumjs-blockchain.md
+++ b/.github/ISSUE_TEMPLATE/package--ethereumjs-blockchain.md
@@ -2,6 +2,9 @@
 name: 'Package: @ethereumjs/blockchain'
 about: Create issue for @ethereumjs/blockchain package
 title: ''
-labels: 'package: blockchain'
+labels: ''
 assignees: ''
+
 ---
+
+

--- a/.github/ISSUE_TEMPLATE/package--ethereumjs-client.md
+++ b/.github/ISSUE_TEMPLATE/package--ethereumjs-client.md
@@ -2,6 +2,9 @@
 name: 'Package: @ethereumjs/client'
 about: Create issue for @ethereumjs/client
 title: ''
-labels: 'package: client'
+labels: ''
 assignees: ''
+
 ---
+
+

--- a/.github/ISSUE_TEMPLATE/package--ethereumjs-common.md
+++ b/.github/ISSUE_TEMPLATE/package--ethereumjs-common.md
@@ -2,6 +2,9 @@
 name: 'Package: @ethereumjs/common'
 about: Create issue for @ethereumjs/common package
 title: ''
-labels: 'package: common'
+labels: ''
 assignees: ''
+
 ---
+
+

--- a/.github/ISSUE_TEMPLATE/package--ethereumjs-devp2p.md
+++ b/.github/ISSUE_TEMPLATE/package--ethereumjs-devp2p.md
@@ -2,6 +2,9 @@
 name: 'Package: @ethereumjs/devp2p'
 about: Create issue for @ethereumjs/devp2p
 title: ''
-labels: 'package: devp2p'
+labels: ''
 assignees: ''
+
 ---
+
+

--- a/.github/ISSUE_TEMPLATE/package--ethereumjs-ethash.md
+++ b/.github/ISSUE_TEMPLATE/package--ethereumjs-ethash.md
@@ -2,6 +2,9 @@
 name: 'Package: @ethereumjs/ethash'
 about: Create issue for @ethereumjs/ethash
 title: ''
-labels: 'package: ethash'
+labels: ''
 assignees: ''
+
 ---
+
+

--- a/.github/ISSUE_TEMPLATE/package--ethereumjs-evm.md
+++ b/.github/ISSUE_TEMPLATE/package--ethereumjs-evm.md
@@ -2,6 +2,9 @@
 name: 'Package: @ethereumjs/evm'
 about: Create issue for @ethereumjs/evm package
 title: ''
-labels: 'package: evm'
+labels: ''
 assignees: ''
+
 ---
+
+

--- a/.github/ISSUE_TEMPLATE/package--ethereumjs-mpt.md
+++ b/.github/ISSUE_TEMPLATE/package--ethereumjs-mpt.md
@@ -2,6 +2,9 @@
 name: 'Package: @ethereumjs/mpt'
 about: Create issue for @ethereumjs/mpt package
 title: ''
-labels: 'package: mpt'
+labels: ''
 assignees: ''
+
 ---
+
+

--- a/.github/ISSUE_TEMPLATE/package--ethereumjs-statemanager.md
+++ b/.github/ISSUE_TEMPLATE/package--ethereumjs-statemanager.md
@@ -2,6 +2,9 @@
 name: 'Package: @ethereumjs/statemanager'
 about: Create issue for @ethereumjs/statemanager
 title: ''
-labels: 'package: statemanager'
+labels: ''
 assignees: ''
+
 ---
+
+

--- a/.github/ISSUE_TEMPLATE/package--ethereumjs-tx.md
+++ b/.github/ISSUE_TEMPLATE/package--ethereumjs-tx.md
@@ -2,6 +2,9 @@
 name: 'Package: @ethereumjs/tx'
 about: Create issue for @ethereumjs/tx package
 title: ''
-labels: 'package: tx'
+labels: ''
 assignees: ''
+
 ---
+
+

--- a/.github/ISSUE_TEMPLATE/package--ethereumjs-util.md
+++ b/.github/ISSUE_TEMPLATE/package--ethereumjs-util.md
@@ -2,6 +2,9 @@
 name: 'Package: @ethereumjs/util'
 about: Create issue for @ethereumjs/util package
 title: ''
-labels: 'package: util'
+labels: ''
 assignees: ''
+
 ---
+
+

--- a/.github/ISSUE_TEMPLATE/package--ethereumjs-verkle.md
+++ b/.github/ISSUE_TEMPLATE/package--ethereumjs-verkle.md
@@ -2,6 +2,9 @@
 name: 'Package: @ethereumjs/verkle'
 about: Create issue for @ethereumjs/verkle package
 title: ''
-labels: 'package: verkle'
+labels: ''
 assignees: ''
+
 ---
+
+

--- a/.github/ISSUE_TEMPLATE/package--ethereumjs-vm.md
+++ b/.github/ISSUE_TEMPLATE/package--ethereumjs-vm.md
@@ -2,6 +2,9 @@
 name: 'Package: @ethereumjs/vm'
 about: Create issue for @ethereumjs/vm package
 title: ''
-labels: 'package: vm'
+labels: ''
 assignees: ''
+
 ---
+
+

--- a/.github/ISSUE_TEMPLATE/package--monorepo.md
+++ b/.github/ISSUE_TEMPLATE/package--monorepo.md
@@ -2,6 +2,9 @@
 name: 'Package: Monorepo'
 about: Create a monorepo-wide issue (e.g. on CI or docs)
 title: ''
-labels: 'package: monorepo'
+labels: ''
 assignees: ''
+
 ---
+
+

--- a/.github/ISSUE_TEMPLATE/package--rlp.md
+++ b/.github/ISSUE_TEMPLATE/package--rlp.md
@@ -2,6 +2,9 @@
 name: 'Package: rlp'
 about: Create issue for rlp package
 title: ''
-labels: 'package: rlp'
+labels: ''
 assignees: ''
+
 ---
+
+


### PR DESCRIPTION
## Summary by Sourcery

Update GitHub issue templates, removing default labels and adding standard ones.

Chores:
- Remove default labels from all existing issue templates.
- Add standard `bug_report`, `feature_request`, and `custom` issue templates.