### PR TITLE
Update docker-image.yml

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20]
+        node-version: [22]
     steps:
       -
         name: Set up QEMU
@@ -40,7 +40,7 @@ jobs:
         working-directory: ${{ github.workspace }}
 
       - name: Build & Push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v4
         with:
           context: .
           push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}


### PR DESCRIPTION
## Summary by Sourcery

Update GitHub Actions Docker image workflow to use Node.js 22 and revert docker/build-push-action to v4

CI:
- Bump Node.js version from 20 to 22 in the Docker image workflow
- Downgrade docker/build-push-action from v5 to v4