### PR TITLE
Create ci-cargo.yml

### DIFF
--- a/.circleci/ci-cargo.yml
+++ b/.circleci/ci-cargo.yml
@@ -1,0 +1,37 @@
+version: 2.1
+
+jobs:
+  build-and-test:
+    docker:
+      - image: cimg/rust:1.88.0
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-cargo-{{ checksum "Cargo.lock" }}
+            - v1-cargo-
+      - run:
+          name: "Check formatting"
+          command: cargo fmt -- --check
+      - run:
+          name: "Run tests"
+          command: cargo test
+      - save_cache:
+          key: v1-cargo-{{ checksum "Cargo.lock" }}
+          paths:
+            - "~/.cargo/bin"
+            - "~/.cargo/registry/index"
+            - "~/.cargo/registry/cache"
+            - "~/.cargo/git/db"
+            - "target"
+      - run:
+          name: "Check formatting"
+          command: cargo fmt -- --check
+      - run:
+          name: "Run tests"
+          command: cargo test
+
+workflows:
+  ci:
+    jobs:
+      - build-and-test


### PR DESCRIPTION
## Summary by Sourcery

Add a new CircleCI pipeline to build and test the Rust code with caching, formatting checks, and unit tests.

CI:
- Add ci-cargo.yml configuration defining a build-and-test job using cimg/rust:1.88.0
- Enable caching of Cargo dependencies keyed by Cargo.lock
- Run cargo fmt checks and cargo test twice to validate code formatting and correctness