### PR TITLE
Potential fix for code scanning alert no. 3344: Regular expression injection

### DIFF
--- a/packages/tx/test/transactionRunner.spec.ts
+++ b/packages/tx/test/transactionRunner.spec.ts
@@ -1,6 +1,7 @@
 import { Common, Mainnet } from '@ethereumjs/common'
 import { EthereumJSErrorWithoutCode, bytesToHex, hexToBytes } from '@ethereumjs/util'
 import minimist from 'minimist'
+import _ from 'lodash'
 import { assert, describe, it } from 'vitest'
 
 import { createTxFromRLP } from '../src/transactionFactory.ts'
@@ -40,7 +41,7 @@ const EIPs: Record<string, number[] | undefined> = {
 }
 
 describe('TransactionTests', async () => {
-  const fileFilterRegex = file !== undefined ? new RegExp(file + '[^\\w]') : undefined
+  const fileFilterRegex = file !== undefined ? new RegExp(_.escapeRegExp(file) + '[^\\w]') : undefined
   await getTests(
     (
       _filename: string,


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/ethereumjs-monorepo/security/code-scanning/3344](https://github.com/Dargon789/ethereumjs-monorepo/security/code-scanning/3344)

To fix this issue, any user-provided input embedded in a regular expression must be sanitized before interpolation. In this context, the `file` variable (parsed from `argv.file`, i.e., a command line argument) must have its regex meta-characters escaped before inserting into the pattern. The recommended method is to use Lodash's `_.escapeRegExp`, which safely escapes all regex-meta characters present in the string.  
Thus, you should:  
- Import lodash (`import _ from 'lodash'`) at the top of the file,
- Replace `new RegExp(file + '[^\\w]')` with `new RegExp(_.escapeRegExp(file) + '[^\\w]')`.

All changes are contained in the given code snippet in `packages/tx/test/transactionRunner.spec.ts`. No other files or changes need to be made.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Prevent regex injection by escaping user-provided filter input in transaction tests

Bug Fixes:
- Sanitize the `file` input when constructing the file filter regex to avoid regex injection

Enhancements:
- Add lodash import to use escapeRegExp for safe regex building